### PR TITLE
Removed default price from result

### DIFF
--- a/client/src/pages/DomainSearch.jsx
+++ b/client/src/pages/DomainSearch.jsx
@@ -37,7 +37,7 @@ const DomainSearch = () => {
           {
             name: result.domain || searchTerm,
             available: result.available,
-            price: result.price || 12.99,
+            price: result.price,
             premium: false,
             registrar: "Namecheap",
             description: `Availability check for ${searchTerm}`,
@@ -66,11 +66,11 @@ const DomainSearch = () => {
             return {
               name: result.domain,
               available: result.available,
-              price: result.available ? result.price || 12.99 : 0,
-              premium: result.isPremium || false,
+              price: result.price ,
+              premium: result.isPremium,
               registrar: "Namecheap",
               description: result.available
-                ? `Available for $${result.price || 12.99}`
+                ? `Available for $${result.price}`
                 : result.reason || "Not available",
             };
           });


### PR DESCRIPTION
This pull request updates the domain search logic in `DomainSearch.jsx` to improve the handling of domain pricing and premium status. The changes ensure that the price and premium status are taken directly from the API response, rather than using default values.

**Domain data handling improvements:**

* Removed default price fallback (`12.99`) and now use the actual `result.price` from the API response for both available and unavailable domains. [[1]](diffhunk://#diff-d48e3d4ad1d6e8e9f4accf1f9eb4463672b9694fd99cda3f458fab663b38f485L40-R40) [[2]](diffhunk://#diff-d48e3d4ad1d6e8e9f4accf1f9eb4463672b9694fd99cda3f458fab663b38f485L69-R73)
* Updated the premium status to use `result.isPremium` directly, rather than defaulting to `false`.
* Adjusted the availability description to display the actual price from the API response.