### PR TITLE
API timeout set to 1 minute

### DIFF
--- a/client/src/services/aiService.js
+++ b/client/src/services/aiService.js
@@ -48,7 +48,7 @@ export const aiService = {
       const timeoutPromise = new Promise((_, reject) => {
         setTimeout(() => {
           reject(new Error("AI request took too long. The AI might be processing complex domain searches. Please try again."));
-        }, 35000); // 35 seconds - slightly longer than API timeout
+        }, 65000); // 65 seconds - slightly longer than API timeout (60 seconds)
       });
 
       const requestPromise = api.post("/ai/chat", {

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -5,7 +5,7 @@ const API_URL =
   import.meta.env.VITE_NGROK_URL ||
   import.meta.env.VITE_API_URL ||
   "http://localhost:5001/api";
-const API_TIMEOUT = import.meta.env.VITE_API_TIMEOUT || 30000; // Increased to 30 seconds for AI requests
+const API_TIMEOUT = import.meta.env.VITE_API_TIMEOUT || 60000; // Increased to 60 seconds (1 minute) for AI requests
 
 console.log("🌐 Using API URL:", API_URL);
 


### PR DESCRIPTION
This pull request increases the timeout settings for AI requests in the client application to better accommodate longer-running operations. The main changes ensure that both the client-side API timeout and the AI service timeout are aligned with the backend's expected processing time.

Timeout configuration updates:

* Increased the default `API_TIMEOUT` in `client/src/services/api.js` from 30 seconds to 60 seconds to allow AI requests more time to complete.
* Extended the AI service request timeout in `client/src/services/aiService.js` from 35 seconds to 65 seconds to ensure it is slightly longer than the API timeout, reducing the chance of premature client-side errors.